### PR TITLE
Add file upload from a local source to geoserver

### DIFF
--- a/lib/geoserver/publish/connection.rb
+++ b/lib/geoserver/publish/connection.rb
@@ -35,6 +35,17 @@ module Geoserver
         raise Geoserver::Publish::Error, response.reason_phrase
       end
 
+      def put(path:, payload:, content_type:)
+        response = faraday_connection.put do |req|
+          req.url path
+          req.headers['Content-Type'] = content_type
+          req.body = payload
+        end
+        return true if response.status == 201 || response.status == 200
+
+        raise Geoserver::Publish::Error, response.reason_phrase
+      end
+
       private
 
         def faraday_connection

--- a/lib/geoserver/publish/data_store.rb
+++ b/lib/geoserver/publish/data_store.rb
@@ -25,11 +25,21 @@ module Geoserver
         connection.post(path: path, payload: payload)
       end
 
+      def upload(workspace_name:, data_store_name:, file:)
+        content_type = 'application/zip'
+        path = upload_url(workspace: workspace_name, data_store: data_store_name)
+        connection.put(path: path, payload: file, content_type: content_type)
+      end
+
       private
 
         def data_store_url(workspace_name:, data_store_name:)
           last_path_component = data_store_name ? "/#{data_store_name}" : ""
           "workspaces/#{workspace_name}/datastores#{last_path_component}"
+        end
+
+        def upload_url(workspace:, data_store:)
+          "workspaces/#{workspace}/datastores/#{data_store}/file.shp"
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/spec/geoserver/publish/connection_spec.rb
+++ b/spec/geoserver/publish/connection_spec.rb
@@ -101,4 +101,30 @@ RSpec.describe Geoserver::Publish::Connection do
       end
     end
   end
+  
+  describe "#put" do
+    let(:path) { "#{base_url}/workspaces/public.json" }
+    let(:payload) { '{"workspace":{"name":"public","isolated":true}}' }
+    let(:content_type) { 'application/json' }
+
+    context "with a 200 updated response" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 200)
+      end
+
+      it "makes a put request to geoserver and returns true" do
+        expect(connection.put(path: path, payload: payload, content_type: 'application/json')).to be true
+      end
+    end
+
+    context "with a 500 response, server error" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 500)
+      end
+
+      it "makes a put request to geoserver and raises an exception" do
+        expect { connection.put(path: path, payload: payload, content_type: 'application/json') }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
 end

--- a/spec/geoserver/publish/data_store_spec.rb
+++ b/spec/geoserver/publish/data_store_spec.rb
@@ -99,4 +99,37 @@ RSpec.describe Geoserver::Publish::DataStore do
       end
     end
   end
+  
+  describe "#upload" do
+    let(:path) { "#{base_url}/workspaces/public/datastores/datastore/file.shp" }
+    let(:payload) { Fixtures.file_fixture("payload/antarctica-latest-free.shp.zip").read }
+    let(:content_type) { 'application/zip' }
+    let(:params) do
+      {
+        workspace_name: workspace_name,
+        data_store_name: data_store_name,
+        file: payload
+      }
+    end
+
+    context "when a datastore is created successfully" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 200)
+      end
+
+      it "returns a the properties as a hash" do
+         expect(datastore_object.upload(params)).to be true
+      end
+    end
+
+    context "when a datastore is not created successfully" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 500)
+      end
+
+      it "raises an exception" do
+        expect { datastore_object.upload(params) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
 end

--- a/spec/support/stub_geoserver.rb
+++ b/spec/support/stub_geoserver.rb
@@ -17,6 +17,12 @@ module GeoserverStubbing
       .with(query: { "recurse" => "true" })
       .to_return(status: status, body: response, headers: {})
   end
+  
+  def stub_geoserver_put(path:, payload:, content_type:, status:)
+    stub_request(:put, path)
+      .with(body: payload, headers: { "Content-Type" => content_type })
+      .to_return(status: status, body: "response", headers: {})
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Allow user to upload a zip file containing shape files from a local source to geoserver and publish it.

Here are some screen shots after uploading a zip file
![ListOfAllLayers](https://user-images.githubusercontent.com/1864660/76262055-a7130480-6218-11ea-8604-f56a9bbb78f3.png)

![layPreview](https://user-images.githubusercontent.com/1864660/76261984-7c28b080-6218-11ea-8ca1-bfefe2069447.png)

Please Review