### PR TITLE
Adds support for additional FeatureType, Coverage, and CoverageStore options on creation

### DIFF
--- a/lib/geoserver/publish/coverage.rb
+++ b/lib/geoserver/publish/coverage.rb
@@ -19,9 +19,9 @@ module Geoserver
         JSON.parse(out) if out
       end
 
-      def create(workspace_name:, coverage_store_name:, coverage_name:, title:)
+      def create(workspace_name:, coverage_store_name:, coverage_name:, title:, additional_payload: nil)
         path = coverage_url(workspace_name: workspace_name, coverage_store_name: coverage_store_name, coverage_name: nil)
-        payload = payload_new(coverage_name: coverage_name, title: title)
+        payload = payload_new(coverage_name: coverage_name, title: title, payload: additional_payload)
         connection.post(path: path, payload: payload)
       end
 
@@ -32,13 +32,13 @@ module Geoserver
           "workspaces/#{workspace_name}/coveragestores/#{coverage_store_name}/coverages#{last_path_component}"
         end
 
-        def payload_new(coverage_name:, title:)
+        def payload_new(coverage_name:, title:, payload: nil)
           {
             coverage: {
               enabled: true,
               name: coverage_name,
               title: title
-            }
+            }.merge(payload.to_h)
           }.to_json
         end
     end

--- a/lib/geoserver/publish/coverage.rb
+++ b/lib/geoserver/publish/coverage.rb
@@ -25,6 +25,12 @@ module Geoserver
         connection.post(path: path, payload: payload)
       end
 
+      def update(workspace_name:, coverage_store_name:, coverage_name:, title:, additional_payload: nil)
+        path = coverage_url(workspace_name: workspace_name, coverage_store_name: coverage_store_name, coverage_name: coverage_name)
+        payload = payload_new(coverage_name: coverage_name, title: title, payload: additional_payload)
+        connection.put(path: path, payload: payload, content_type: "application/json")
+      end
+
       private
 
         def coverage_url(workspace_name:, coverage_store_name:, coverage_name:)

--- a/lib/geoserver/publish/coverage_store.rb
+++ b/lib/geoserver/publish/coverage_store.rb
@@ -19,9 +19,9 @@ module Geoserver
         JSON.parse(out) if out
       end
 
-      def create(workspace_name:, coverage_store_name:, url:, type: "GeoTIFF")
+      def create(workspace_name:, coverage_store_name:, url:, type: "GeoTIFF", additional_payload: nil)
         path = coverage_store_url(workspace_name: workspace_name, coverage_store_name: nil)
-        payload = payload_new(workspace_name: workspace_name, coverage_store_name: coverage_store_name, url: url, type: type)
+        payload = payload_new(workspace_name: workspace_name, coverage_store_name: coverage_store_name, url: url, type: type, payload: additional_payload)
         connection.post(path: path, payload: payload)
       end
 
@@ -32,7 +32,7 @@ module Geoserver
           "workspaces/#{workspace_name}/coveragestores#{last_path_component}"
         end
 
-        def payload_new(workspace_name:, coverage_store_name:, type:, url:)
+        def payload_new(workspace_name:, coverage_store_name:, type:, url:, payload:)
           {
             coverageStore: {
               name: coverage_store_name,
@@ -43,7 +43,7 @@ module Geoserver
               },
               type: type,
               _default: false
-            }
+            }.merge(payload.to_h)
           }.to_json
         end
     end

--- a/lib/geoserver/publish/coverage_store.rb
+++ b/lib/geoserver/publish/coverage_store.rb
@@ -25,6 +25,12 @@ module Geoserver
         connection.post(path: path, payload: payload)
       end
 
+      def update(workspace_name:, coverage_store_name:, url:, type: "GeoTIFF", additional_payload: nil)
+        path = coverage_store_url(workspace_name: workspace_name, coverage_store_name: coverage_store_name)
+        payload = payload_new(workspace_name: workspace_name, coverage_store_name: coverage_store_name, url: url, type: type, payload: additional_payload)
+        connection.put(path: path, payload: payload, content_type: "application/json")
+      end
+
       private
 
         def coverage_store_url(workspace_name:, coverage_store_name:)

--- a/lib/geoserver/publish/feature_type.rb
+++ b/lib/geoserver/publish/feature_type.rb
@@ -27,6 +27,12 @@ module Geoserver
         connection.post(path: path, payload: payload)
       end
 
+      def update(workspace_name:, data_store_name:, feature_type_name:, title:, additional_payload: nil)
+        path = feature_type_url(workspace_name: workspace_name, data_store_name: data_store_name, feature_type_name: feature_type_name)
+        payload = payload_new(feature_type_name: feature_type_name, title: title, payload: additional_payload)
+        connection.put(path: path, payload: payload, content_type: "application/json")
+      end
+
       private
 
         def feature_type_url(workspace_name:, data_store_name:, feature_type_name:)

--- a/lib/geoserver/publish/feature_type.rb
+++ b/lib/geoserver/publish/feature_type.rb
@@ -21,9 +21,9 @@ module Geoserver
 
       # Feature type name must be the same name as the shapefile without the extenstion.
       # E.g. If the file is `12345.shp`, then feature_type_name = "12345".
-      def create(workspace_name:, data_store_name:, feature_type_name:, title:)
+      def create(workspace_name:, data_store_name:, feature_type_name:, title:, additional_payload: nil)
         path = feature_type_url(workspace_name: workspace_name, data_store_name: data_store_name, feature_type_name: nil)
-        payload = payload_new(feature_type_name: feature_type_name, title: title)
+        payload = payload_new(feature_type_name: feature_type_name, title: title, payload: additional_payload)
         connection.post(path: path, payload: payload)
       end
 
@@ -34,13 +34,13 @@ module Geoserver
           "workspaces/#{workspace_name}/datastores/#{data_store_name}/featuretypes#{last_path_component}"
         end
 
-        def payload_new(feature_type_name:, title:)
+        def payload_new(feature_type_name:, title:, payload:)
           {
             featureType: {
               name: feature_type_name,
               title: title,
               enabled: true
-            }
+            }.merge(payload.to_h)
           }.to_json
         end
     end

--- a/spec/geoserver/publish/coverage_spec.rb
+++ b/spec/geoserver/publish/coverage_spec.rb
@@ -49,6 +49,28 @@ RSpec.describe Geoserver::Publish::Coverage do
         expect { coverage_object.create(params) }.to raise_error(Geoserver::Publish::Error)
       end
     end
+
+    context "allows for custom payload parameters to be added to the request" do
+      let(:params) do
+        {
+          workspace_name: workspace_name,
+          coverage_store_name: coverage_store_name,
+          coverage_name: coverage_name,
+          title: title,
+          additional_payload: {
+            description: "Describe the coverage"
+          }
+        }
+      end
+
+      it "creates a Coverage with additional payload" do
+        new_payload = JSON.parse(payload)
+        new_payload["coverage"].merge!(params[:additional_payload])
+        stubbed = stub_geoserver_post(path: path, payload: new_payload.to_json, status: 201)
+        coverage_object.create(params)
+        expect(stubbed).to have_been_requested
+      end
+    end
   end
 
   describe "#delete" do

--- a/spec/geoserver/publish/coverage_spec.rb
+++ b/spec/geoserver/publish/coverage_spec.rb
@@ -73,6 +73,45 @@ RSpec.describe Geoserver::Publish::Coverage do
     end
   end
 
+  describe "#update" do
+    let(:payload) { Fixtures.file_fixture("payload/coverage.json").read }
+    let(:params) do
+      {
+        workspace_name: workspace_name,
+        coverage_store_name: coverage_store_name,
+        coverage_name: coverage_name,
+        title: title,
+        additional_payload: {
+          keywords: {
+            "string": ["coverage"]
+          }
+        }
+      }
+    end
+
+    context "with a 200 OK response" do
+      it "makes a put request and returns true" do
+        new_payload = JSON.parse(payload)
+        new_payload["coverage"].merge!(params[:additional_payload])
+        stub_geoserver_put(payload: new_payload.to_json, path: path, status: 200, content_type: "application/json")
+
+        expect(coverage_object.update(params)).to be true
+      end
+    end
+
+    context "with a 404 not found response" do
+      let(:response) { "not found" }
+
+      it "makes an update request to geoserver and raises an exception" do
+        new_payload = JSON.parse(payload)
+        new_payload["coverage"].merge!(params[:additional_payload])
+        stub_geoserver_put(payload: new_payload.to_json, path: path, status: 404, content_type: "application/json")
+
+        expect { coverage_object.update(params) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
+
   describe "#delete" do
     context "with a 200 OK response" do
       let(:response) { "" }

--- a/spec/geoserver/publish/coverage_store_spec.rb
+++ b/spec/geoserver/publish/coverage_store_spec.rb
@@ -72,6 +72,44 @@ RSpec.describe Geoserver::Publish::CoverageStore do
     end
   end
 
+  describe "#update" do
+    let(:payload) { Fixtures.file_fixture("payload/coveragestore.json").read }
+    let(:params) do
+      {
+        workspace_name: workspace_name,
+        coverage_store_name: coverage_store_name,
+        url: url,
+        additional_payload: {
+          keywords: {
+            "string": ["coverage", "store"]
+          }
+        }
+      }
+    end
+
+    context "with a 200 OK response" do
+      it "makes a put request and returns true" do
+        new_payload = JSON.parse(payload)
+        new_payload["coverageStore"].merge!(params[:additional_payload])
+        stub_geoserver_put(payload: new_payload.to_json, path: path, status: 200, content_type: "application/json")
+
+        expect(coveragestore_object.update(params)).to be true
+      end
+    end
+
+    context "with a 404 not found response" do
+      let(:response) { "not found" }
+
+      it "makes an update request to geoserver and raises an exception" do
+        new_payload = JSON.parse(payload)
+        new_payload["coverageStore"].merge!(params[:additional_payload])
+        stub_geoserver_put(payload: new_payload.to_json, path: path, status: 404, content_type: "application/json")
+
+        expect { coveragestore_object.update(params) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
+
   describe "#delete" do
     context "with a 200 OK response" do
       let(:response) { "" }

--- a/spec/geoserver/publish/coverage_store_spec.rb
+++ b/spec/geoserver/publish/coverage_store_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe Geoserver::Publish::CoverageStore do
         expect { coveragestore_object.create(params) }.to raise_error(Geoserver::Publish::Error)
       end
     end
+
+    context "allows for custom payload parameters to be added to the request" do
+      let(:params) do
+        {
+          workspace_name: workspace_name,
+          coverage_store_name: coverage_store_name,
+          url: url,
+          additional_payload: {
+            metadata: {
+              "cacheAgeMax" => 86_400,
+              "cachingEnabled" => true
+            }
+          }
+        }
+      end
+
+      it "creates a CoverageStore with additional payload" do
+        new_payload = JSON.parse(payload)
+        new_payload["coverageStore"].merge!(params[:additional_payload])
+        stubbed = stub_geoserver_post(path: path, payload: new_payload.to_json, status: 201)
+        coveragestore_object.create(params)
+        expect(stubbed).to have_been_requested
+      end
+    end
   end
 
   describe "#delete" do

--- a/spec/geoserver/publish/feature_type_spec.rb
+++ b/spec/geoserver/publish/feature_type_spec.rb
@@ -49,6 +49,31 @@ RSpec.describe Geoserver::Publish::FeatureType do
         expect { feature_type_object.create(params) }.to raise_error(Geoserver::Publish::Error)
       end
     end
+
+    context "allows for custom payload parameters to be added to the request" do
+      let(:params) do
+        {
+          workspace_name: workspace_name,
+          data_store_name: data_store_name,
+          feature_type_name: feature_type_name,
+          title: title,
+          additional_payload: {
+            metadata: {
+              "cacheAgeMax" => 86_400,
+              "cachingEnabled" => true
+            }
+          }
+        }
+      end
+
+      it "creates a layer with additional payload" do
+        new_payload = JSON.parse(payload)
+        new_payload["featureType"].merge!(params[:additional_payload])
+        stubbed = stub_geoserver_post(path: path, payload: new_payload.to_json, status: 201)
+        feature_type_object.create(params)
+        expect(stubbed).to have_been_requested
+      end
+    end
   end
 
   describe "#delete" do

--- a/spec/geoserver/publish/feature_type_spec.rb
+++ b/spec/geoserver/publish/feature_type_spec.rb
@@ -76,6 +76,46 @@ RSpec.describe Geoserver::Publish::FeatureType do
     end
   end
 
+  describe "#update" do
+    let(:payload) { Fixtures.file_fixture("payload/feature_type.json").read }
+    let(:params) do
+      {
+        workspace_name: workspace_name,
+        data_store_name: data_store_name,
+        feature_type_name: feature_type_name,
+        title: title,
+        additional_payload: {
+          metadata: {
+            "cacheAgeMax" => 86_400,
+            "cachingEnabled" => true
+          }
+        }
+      }
+    end
+
+    context "with a 200 OK response" do
+      it "makes a put request and returns true" do
+        new_payload = JSON.parse(payload)
+        new_payload["featureType"].merge!(params[:additional_payload])
+        stub_geoserver_put(payload: new_payload.to_json, path: path, status: 200, content_type: "application/json")
+
+        expect(feature_type_object.update(params)).to be true
+      end
+    end
+
+    context "with a 404 not found response" do
+      let(:response) { "not found" }
+
+      it "makes an update request to geoserver and raises an exception" do
+        new_payload = JSON.parse(payload)
+        new_payload["featureType"].merge!(params[:additional_payload])
+        stub_geoserver_put(payload: new_payload.to_json, path: path, status: 404, content_type: "application/json")
+
+        expect { feature_type_object.update(params) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
+
   describe "#delete" do
     context "with a 200 OK response" do
       let(:response) { "" }


### PR DESCRIPTION
This PR adds the ability to provide additional payload for creating FeatureTypes, Coverage, and CoverageStores. This was done in a backwards compatible way so that current adopters shouldn't lose any functionality.

This PR also adds the `#update` method for each of these classes that can also take this additional payload.


```ruby
Geoserver::Publish::FeatureType.new.update(workspace_name: 'druid', data_store_name: 'gis_osm_buildings_a_free
_1', feature_type_name: 'gis_osm_buildings_a_free_1', title: 'stufdddf', additional_payload: { keywords: ['gisstuff'], metadata
: {'cacheAgeMax': 0}, abstract: 'testab'})
```