### PR TITLE
Adds support for RESTful operations on Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Geoserver::Publish.delete_geotiff(workspace_name: "public", id: "1234")
 Geoserver::Publish.delete_shapefile(workspace_name: "public", id: "1234")
 ```
 
+#### Styles
+
+For users wanting to publish styles, this can be done using the [GeoServer styles API](https://docs.geoserver.org/latest/en/api/#1.0.0/styles.yaml).
+
+```ruby
+Geoserver::Publish::Style.new.create(style_name: "raster_layer", filename: "raster_layer.sld")
+sld = File.read("./spec/fixtures/files/payload/raster_layer.sld")
+Geoserver::Publish::Style.new.update(style_name: "raster_layer", filename: "raster_layer.sld", payload: sld)
+```
+
 ## Configuration
 
 #### Default

--- a/lib/geoserver/publish.rb
+++ b/lib/geoserver/publish.rb
@@ -13,6 +13,7 @@ module Geoserver
     require "geoserver/publish/create"
     require "geoserver/publish/data_store"
     require "geoserver/publish/feature_type"
+    require "geoserver/publish/style"
     require "geoserver/publish/version"
     require "geoserver/publish/workspace"
 

--- a/lib/geoserver/publish/style.rb
+++ b/lib/geoserver/publish/style.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module Geoserver
+  module Publish
+    ##
+    # Class for interacting with GeoServer Styles API.
+    # **NOTE** This assumes only the top level styles path /styles and does not
+    # work with workspace and layer based styles.
+    class Style
+      attr_reader :connection
+
+      def initialize(conn = nil)
+        @connection = conn || Geoserver::Publish::Connection.new
+      end
+
+      def delete(style_name:)
+        path = style_url(style_name: style_name)
+        connection.delete(path: path)
+      end
+
+      def find(style_name:)
+        path = style_url(style_name: style_name)
+        out = connection.get(path: path)
+        JSON.parse(out) if out
+      end
+
+      ##
+      # Create will update the GeoServer catalog, but not provide the style
+      def create(style_name:, filename:, additional_payload: nil)
+        path = style_url(style_name: nil)
+        payload = payload_new(style_name: style_name, filename: filename, payload: additional_payload)
+        connection.post(path: path, payload: payload)
+      end
+
+      ##
+      # Update requires and uses the payload to upload an SLD
+      def update(style_name:, filename:, payload:)
+        path = style_url(style_name: style_name)
+        connection.put(path: path, payload: payload, content_type: "application/vnd.ogc.sld+xml")
+      end
+
+      private
+
+        def style_url(style_name:)
+          last_path_component = style_name ? "/#{style_name}" : ""
+          "styles#{last_path_component}"
+        end
+
+        def payload_new(style_name:, filename:, payload: nil)
+          {
+            style: {
+              name: style_name,
+              filename: filename,
+            }.merge(payload.to_h)
+          }.to_json
+        end
+    end
+  end
+end

--- a/spec/fixtures/files/payload/raster_layer.sld
+++ b/spec/fixtures/files/payload/raster_layer.sld
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
+  <UserLayer>
+    <Name>raster_layer</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <RasterSymbolizer>
+            <ColorMap>
+              <ColorMapEntry color="#000000" quantity="0" opacity="1"/>
+              <ColorMapEntry color="#FFFFFF" quantity="255" opacity="1"/>
+            </ColorMap>
+          </RasterSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </UserLayer>
+</StyledLayerDescriptor>

--- a/spec/fixtures/files/payload/style.json
+++ b/spec/fixtures/files/payload/style.json
@@ -1,0 +1,1 @@
+{"style":{"name":"raster_layer","filename":"raster_layer.sld"}}

--- a/spec/fixtures/files/response/style.json
+++ b/spec/fixtures/files/response/style.json
@@ -1,0 +1,1 @@
+{"style":{"name":"raster_layer","format":"sld","languageVersion":{"version":"1.0.0"},"filename":"raster_layer.sld"}}

--- a/spec/geoserver/publish/style_spec.rb
+++ b/spec/geoserver/publish/style_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Geoserver::Publish::Style do
+  subject(:style_object) { described_class.new }
+  let(:base_url) { "http://localhost:8080/geoserver/rest" }
+  let(:path) { "#{base_url}/styles/#{style_name}" }
+  let(:style_name) { "raster_layer" }
+  let(:filename) { "raster_layer.sld" }
+
+  describe "#create" do
+    let(:path) { "#{base_url}/styles" }
+    let(:payload) { Fixtures.file_fixture("payload/style.json").read.strip }
+
+    context "when a style is created successfully" do
+      before do
+        stub_geoserver_post(path: path, payload: payload, status: 201)
+      end
+
+      it "returns a true" do
+        expect(style_object.create(style_name: style_name, filename: filename)).to be true
+      end
+    end
+
+    context "when a style is not created successfully" do
+      before do
+        stub_geoserver_post(path: path, payload: payload, status: 500)
+      end
+
+      it "raises an error" do
+        expect { style_object.create(style_name: style_name, filename: filename) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
+
+  describe "#delete" do
+    context "with a 200 OK response" do
+      let(:response) { "" }
+
+      before do
+        stub_geoserver_delete(path: path, response: response, status: 200)
+      end
+
+      it "makes a delete request and returns true" do
+        expect(style_object.delete(style_name: style_name)).to be true
+      end
+    end
+
+    context "with a 404 not found response" do
+      let(:response) { "not found" }
+
+      before do
+        stub_geoserver_delete(path: path, response: response, status: 404)
+      end
+
+      it "makes a delete request to geoserver and raises an exception" do
+        expect { style_object.delete(style_name: style_name) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:payload) { Fixtures.file_fixture("payload/raster_layer.sld").read }
+
+    context "with a 200 OK response" do
+      it "makes a put request and returns true" do
+        stub_geoserver_put(payload: payload, path: path, status: 200, content_type: "application/vnd.ogc.sld+xml")
+
+        expect(style_object.update(style_name: style_name, filename: filename, payload: payload)).to be true
+      end
+    end
+
+    context "with a 404 not found response" do
+      let(:response) { "not found" }
+
+      it "makes an update request to geoserver and raises an exception" do
+        stub_geoserver_put(payload: payload, path: path, status: 404, content_type: "application/vnd.ogc.sld+xml")
+
+        expect { style_object.update(style_name: style_name, filename: filename, payload: payload) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
+
+  describe "#find" do
+    context "when a style is found" do
+      let(:response) { Fixtures.file_fixture("response/style.json").read }
+
+      before do
+        stub_geoserver_get(path: path, response: response, status: 200)
+      end
+
+      it "returns a the properties as a hash" do
+        expect(style_object.find(style_name: style_name)).to eq(JSON.parse(response))
+      end
+    end
+
+    context "when a style is not found" do
+      let(:response) { "not found" }
+
+      before do
+        stub_geoserver_get(path: path, response: response, status: 404)
+      end
+
+      it "returns nil" do
+        expect(style_object.find(style_name: style_name)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #10 by providing a REST client for GeoServer Styles.

As noted in the class comments, the GeoServer Style API can support style creations in individual workspaces and layers, however, this PR only implements them at the top level.

See: https://docs.geoserver.org/latest/en/api/#1.0.0/styles.yaml

README documentation also update:

 ```ruby
# via ./bin/console
Geoserver::Publish::Style.new.create(style_name: "raster_layer", filename: "raster_layer.sld")
sld = File.read("./spec/fixtures/files/payload/raster_layer.sld")
Geoserver::Publish::Style.new.update(style_name: "raster_layer", filename: "raster_layer.sld", payload: sld)
```