### PR TITLE
Allow DataStore#upload to support all put methods

### DIFF
--- a/lib/geoserver/publish/data_store.rb
+++ b/lib/geoserver/publish/data_store.rb
@@ -25,9 +25,19 @@ module Geoserver
         connection.post(path: path, payload: payload)
       end
 
-      def upload(workspace_name:, data_store_name:, file:)
+      ##
+      # Upload a shapefile zip to a new datastore
+      # # @param workspace_name [String]
+      # # @param data_store_name [String]
+      # # @param file [String] Depending on value of method:
+      #     file == binary stream
+      #     url == URL to publicly available shapezip zip.
+      #     external == absolute path to existing file
+      # # @param method [String] Can be one of 'file', 'url', 'external'.
+      #     See: https://docs.geoserver.org/stable/en/api/#1.0.0/datastores.yaml
+      def upload(workspace_name:, data_store_name:, file:, method: 'file')
         content_type = 'application/zip'
-        path = upload_url(workspace: workspace_name, data_store: data_store_name)
+        path = upload_url(workspace: workspace_name, data_store: data_store_name, method: method)
         connection.put(path: path, payload: file, content_type: content_type)
       end
 
@@ -38,8 +48,8 @@ module Geoserver
           "workspaces/#{workspace_name}/datastores#{last_path_component}"
         end
 
-        def upload_url(workspace:, data_store:)
-          "workspaces/#{workspace}/datastores/#{data_store}/file.shp"
+        def upload_url(workspace:, data_store:, method:)
+          "workspaces/#{workspace}/datastores/#{data_store}/#{method}.shp"
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/lib/geoserver/publish/version.rb
+++ b/lib/geoserver/publish/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Geoserver
   module Publish
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end

--- a/spec/geoserver/publish/data_store_spec.rb
+++ b/spec/geoserver/publish/data_store_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Geoserver::Publish::DataStore do
       end
     end
   end
-  
+
   describe "#upload" do
     let(:path) { "#{base_url}/workspaces/public/datastores/datastore/file.shp" }
     let(:payload) { Fixtures.file_fixture("payload/antarctica-latest-free.shp.zip").read }
@@ -112,7 +112,18 @@ RSpec.describe Geoserver::Publish::DataStore do
       }
     end
 
-    context "when a datastore is created successfully" do
+    context "when a datastore is created using the url method" do
+      let(:path) { "#{base_url}/workspaces/public/datastores/datastore/url.shp" }
+      let(:payload) { "http://example.com/antarctica-latest-free.shp.zip" }
+      let(:params) do
+        {
+          workspace_name: workspace_name,
+          data_store_name: data_store_name,
+          file: payload,
+          method: 'url'
+        }
+    end
+
       before do
         stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 200)
       end
@@ -122,7 +133,17 @@ RSpec.describe Geoserver::Publish::DataStore do
       end
     end
 
-    context "when a datastore is not created successfully" do
+    context "when a datastore is created using the file method" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 200)
+      end
+
+      it "returns true" do
+         expect(datastore_object.upload(params)).to be true
+      end
+    end
+
+    context "when a datastore is not created using the file method" do
       before do
         stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 500)
       end


### PR DESCRIPTION
Per the documentation in GeoServer, creating a datastore via the REST
API is possibly not only by uploading a file, but also by referencing a
remote URL, or an existing (absolute) reference to a file on the
Geoserver.

see: https://docs.geoserver.org/stable/en/api/#1.0.0/datastores.yaml

This commit aims to support all 3 documented options by introducing the
`method` parameter to `DataStore#upload` and using a default value of
`file` to match the previous default implementation added by @VivianChu 

Testing:
I admit I'm not sure that the added test coverage is adequate and happy to make adjustments there as needed. However local testing with this change does successfully ingest shapefile zip files hosted on a remote server into GeoServer, which was the motivation behind this PR.