### PR TITLE
Update references of hard-coded legacy master branch name to main branch name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /tmp/
 .byebug_history
 .rspec_status
+.tool-versions
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geoserver::Publish
 
-[![Build Status](https://img.shields.io/travis/samvera-labs/geoserver-publish/master.svg)](https://travis-ci.org/samvera-labs/geoserver-publish)
-[![Coverage Status](https://img.shields.io/coveralls/samvera-labs/geoserver-publish/master.svg)](https://coveralls.io/github/samvera-labs/geoserver-publish?branch=master)
+[![Build Status](https://img.shields.io/travis/samvera-labs/geoserver-publish/main.svg)](https://travis-ci.org/samvera-labs/geoserver-publish)
+[![Coverage Status](https://img.shields.io/coveralls/samvera-labs/geoserver-publish/main.svg)](https://coveralls.io/github/samvera-labs/geoserver-publish?branch=main)
 
 Simple client for publishing Shapefiles and GeoTIFFs to Geoserver.
 
@@ -102,4 +102,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/samver
 
 If you're working on a PR for this project, create a feature branch off of `main`. 
 
-This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [language recommendations](https://github.com/samvera/maintenance/blob/master/templates/CONTRIBUTING.md#language).  Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.
+This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [language recommendations](https://github.com/samvera/maintenance/blob/main/templates/CONTRIBUTING.md#language).  Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.

--- a/geoserver-publish.gemspec
+++ b/geoserver-publish.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", "~> 2.2"
 
   spec.add_development_dependency "bundler", "> 1.16.0", "< 3"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/geoserver/publish/connection.rb
+++ b/lib/geoserver/publish/connection.rb
@@ -38,7 +38,7 @@ module Geoserver
       def put(path:, payload:, content_type:)
         response = faraday_connection.put do |req|
           req.url path
-          req.headers['Content-Type'] = content_type
+          req.headers["Content-Type"] = content_type
           req.body = payload
         end
         return true if response.status == 201 || response.status == 200
@@ -48,12 +48,12 @@ module Geoserver
 
       private
 
-        def faraday_connection
-          Faraday.new(url: config["url"]) do |conn|
-            conn.adapter Faraday.default_adapter
-            conn.basic_auth(config["user"], config["password"]) if config["user"]
-          end
+      def faraday_connection
+        Faraday.new(url: config["url"]) do |conn|
+          conn.adapter Faraday.default_adapter
+          conn.request(:authorization, :basic, config["user"], config["password"]) if config["user"]
         end
+      end
     end
   end
 end


### PR DESCRIPTION
- Add .tool-versions file to .gitignore
- Update Faraday basic auth configuration and pin the version
- Update references of hard-coded legacy master branch name to main branch name

Closes #23 