### PR TITLE
Support upload/put for geotiffs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   bixby: bixby_default.yml
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   Exclude:
     - 'bin/*'
 Lint/UnusedMethodArgument:
@@ -13,7 +13,7 @@ Metrics/BlockLength:
     - "spec/**/*"
     - "*.gemspec"
 Naming/FileName:
-  Exclude: 
+  Exclude:
     - "geoserver-publish.gemspec"
     - "Gemfile"
 Style/StringLiterals:

--- a/lib/geoserver/publish/coverage_store.rb
+++ b/lib/geoserver/publish/coverage_store.rb
@@ -31,11 +31,46 @@ module Geoserver
         connection.put(path: path, payload: payload, content_type: "application/json")
       end
 
+      ##
+      # Upload raster data files to a new coverage store
+      # # @param workspace_name [String]
+      # # @param coverage_store_name [String]
+      # # @param format [String] One of:
+      #     geotiff == GeoTIFF
+      #     worldimage == Georeferenced image (JPEG, PNG, TIFF)
+      #     imagemosaic == Image mosaic
+      #     See: https://docs.geoserver.org/stable/en/user/rest/api/coveragestores.html#extension
+      # # @param file [String] Depending on value of method:
+      #     file == binary stream
+      #     url == URL to publicly available raster files (DOESN'T ACTUALLY WORK).
+      #     external == absolute path to existing file
+      # # @param content_type [String] Content-Type for file upload
+      # # @param method [String] Can be one of 'file', 'url', 'external'.
+      #     See: https://docs.geoserver.org/latest/en/api/#1.0.0/coveragestores.yaml
+      # rubocop:disable Metrics/ParameterLists
+      def upload(workspace_name:, coverage_store_name:, format:, file:, method: "file", content_type: "application/zip")
+        path = upload_url(
+          workspace_name: workspace_name,
+          coverage_store_name: coverage_store_name,
+          method: method,
+          format: format
+        )
+
+        connection.put(path: path, payload: file, content_type: content_type)
+      end
+      # rubocop:enable Metrics/ParameterLists
+
       private
 
       def coverage_store_url(workspace_name:, coverage_store_name:)
         last_path_component = coverage_store_name ? "/#{coverage_store_name}" : ""
         "workspaces/#{workspace_name}/coveragestores#{last_path_component}"
+      end
+
+      # see: https://docs.geoserver.org/latest/en/api/#1.0.0/coveragestores.yaml
+      # /workspaces/{workspace}/coveragestores/{store}/{method}.{format}
+      def upload_url(workspace_name:, coverage_store_name:, method:, format:)
+        "workspaces/#{workspace_name}/coveragestores/#{coverage_store_name}/#{method}.#{format}?coverageName=#{coverage_store_name}"
       end
 
       def payload_new(workspace_name:, coverage_store_name:, type:, url:, payload:)

--- a/lib/geoserver/publish/version.rb
+++ b/lib/geoserver/publish/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Geoserver
   module Publish
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/spec/geoserver/publish/coverage_store_spec.rb
+++ b/spec/geoserver/publish/coverage_store_spec.rb
@@ -161,4 +161,39 @@ RSpec.describe Geoserver::Publish::CoverageStore do
       end
     end
   end
+
+  describe "#upload" do
+    let(:path) { "#{base_url}/workspaces/public/coveragestores/#{coverage_store_name}/file.geotiff?coverageName=#{coverage_store_name}" }
+    let(:payload) { Fixtures.file_fixture("payload/sample.tif").read }
+    let(:content_type) { "image/tiff" }
+    let(:params) do
+      {
+        workspace_name: workspace_name,
+        coverage_store_name: coverage_store_name,
+        format: "geotiff",
+        file: payload,
+        method: "file",
+        content_type: content_type
+      }
+    end
+    context "when a coveragestore is created using the file method" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 200)
+      end
+
+      it "returns true" do
+        expect(coveragestore_object.upload(params)).to be true
+      end
+    end
+
+    context "when a coveragestore is not created using the file method" do
+      before do
+        stub_geoserver_put(path: path, payload: payload, content_type: content_type, status: 500)
+      end
+
+      it "raises an exception" do
+        expect { coveragestore_object.upload(params) }.to raise_error(Geoserver::Publish::Error)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Fix broken rubocop configuration so it tests successfully in CI (needed to bump target Ruby version to match CI)
* Support upload/put for geotiffs, similar to what was already in place for shapefiles
* Bump version to `0.7.0`